### PR TITLE
Add redirection of the root route to the API endpoint

### DIFF
--- a/checkin/urls.py
+++ b/checkin/urls.py
@@ -15,8 +15,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from .views import ApiRootView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('flights/', include("flight.urls")),
+    path('', ApiRootView.as_view(), name='api-root'),
 ]

--- a/checkin/views.py
+++ b/checkin/views.py
@@ -1,0 +1,25 @@
+from django.urls import reverse
+from django.utils.module_loading import import_module
+from rest_framework.views import APIView
+from django.conf import settings
+from django.shortcuts import redirect
+
+
+class ApiRootView(APIView):
+    def get(self, request, format=None):
+
+        for app_name in settings.INSTALLED_APPS:
+            try:
+                if app_name == "flight":
+                    app_urls = import_module(f"{app_name}.urls")
+                    if app_urls:
+                        for url in app_urls.urlpatterns:
+                            if url.name == "flight-passengers":
+
+                                url_with_id = reverse(
+                                    "flight-passengers", kwargs={"id": 1}
+                                )
+
+            except ModuleNotFoundError:
+                pass
+        return redirect(url_with_id)


### PR DESCRIPTION
An APIVIEW called ApiRootView was created to redirect the root route to the API endpoint "/flights/1/passengers".